### PR TITLE
Allow a multi-character prefix to be given, rather than a byte value.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,16 +12,20 @@ Allows to generate public addresses with custom prefix which consists of a speci
 
 ## Usage
 
-`pnpm run dry [BYTE_VALUE] [SEED_LENGTH]`
+`pnpm run dry [PREFIX] [SEED_LENGTH]`
 
 Both arguments are optional.
 
-Default byte value is `"55"`.
+The default prefix is `"1234"`.
 
 Default seed length is `16`. The seed length must be divisible by 4. Currently at least iOS app doesn't support longer mnemonic phrases than 13 words (corresponds to the default seed length). So unless you know what you're doing, it's advised not to touch the seed length parameter.
 
 ### Example:
 
-`pnpm run dry 00`
+`pnpm run dry 1248 32`
 
 Technically you can run multiple instances to simulate multithreading and thus speed up the brute force.
+
+## Warning:
+
+If you choose a prefix length of more than a few characters, you may die before the program finishes executing.

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,34 +53,24 @@ async function generateKeyPair(seed: Uint8Array) {
   };
 }
 
-let prefixHex = process.argv[2] || "55";
-let prefixByte = Buffer.from(prefixHex, "hex").readUint8();
-let prefixLength = 1;
-
+let vanityPrefix = process.argv[2] || "1234";
 let seedLength = parseFloat(process.argv[3]);
 seedLength = isNaN(seedLength) ? 16 : seedLength;
 
 if (seedLength % 4) throw "Seed size must be divisible by 4";
 
-console.log(`Starting a search for addresses that start with "${prefixHex}" byte`);
-console.log("Seed size is set to", seedLength);
+console.log("Seed size set to", seedLength);
+console.log(`Starting a search for addresses that start with '${vanityPrefix}'...`);
 
-while (true) {
-  let seed = await generateSeed(seedLength);
+let newHexPubKey = '';
+let seed;
+
+while (newHexPubKey.substring(0, vanityPrefix.length) !== vanityPrefix) {
+  seed = await generateSeed(seedLength);
   let pub = await derivePublicKey(seed);
-
-  let p = 0;
-  for (; p < prefixLength; p += 1) {
-    if (pub[p] !== prefixByte) {
-      break;
-    }
-  }
-
-  if (p === prefixLength) {
-    console.log("Length", prefixLength);
-    console.log("05" + Buffer.from(pub).toString("hex"));
-    console.log(deriveMnemonic(seed));
-
-    prefixLength += 1;
-  }
+  newHexPubKey = Buffer.from(pub).toString("hex");
 }
+
+let mnemonic = await deriveMnemonic(seed);
+console.log("Session id: 05" + newHexPubKey);
+console.log("Recovery phrase: " + mnemonic);


### PR DESCRIPTION
For greater flexibility, it would be nice to be able to specify a character prefix of arbitrary length, rather than a byte value.